### PR TITLE
Fix a bug causing "No current path detected!" due to use of out of date plugin API

### DIFF
--- a/open_current_path_with_editor/__init__.py
+++ b/open_current_path_with_editor/__init__.py
@@ -1,12 +1,13 @@
 from core.commands import OpenWithEditor
 from fman import show_alert
+from fman.url import as_human_readable
 from os.path import exists
 
 class OpenCurrentPathWithEditor(OpenWithEditor):
     def __call__(self):
         path_to_open = self.pane.get_path()
 
-        if exists(path_to_open):
-            self._open_with_editor(path_to_open)
+        if exists(as_human_readable(path_to_open)):
+            super().__call__(path_to_open)
         else:
             show_alert('No current path detected!')


### PR DESCRIPTION
The current api seems to pass a URI instead of a normal path, causing python's `exists` to return false. Fix was to pass a normal path to exists.

Also, OpenWithEditor no longer has an _open_with_editor method.
